### PR TITLE
move shader copy after CompileShaders target fix #14

### DIFF
--- a/glRemixRenderer/CMakeLists.txt
+++ b/glRemixRenderer/CMakeLists.txt
@@ -109,13 +109,6 @@ if(GLREMIX_DEPLOY_DIR)
         )
     endif()
 
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E echo "Copying shader files to ${_GLREMIX_RENDERER_DEPLOY_CONFIG_DIR}/shaders"
-        COMMAND ${CMAKE_COMMAND} -E make_directory "${_GLREMIX_RENDERER_DEPLOY_CONFIG_DIR}/shaders"
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-            "${CMAKE_CURRENT_BINARY_DIR}/shaders"
-            "${_GLREMIX_RENDERER_DEPLOY_CONFIG_DIR}/shaders"
-    )
 endif()
 
 if(WIN32)
@@ -181,3 +174,13 @@ add_custom_target(CompileShaders ALL
 )
 
 add_dependencies(${PROJECT_NAME} CompileShaders)
+
+if(GLREMIX_DEPLOY_DIR)
+    add_custom_command(TARGET CompileShaders POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E echo "Copying shader files to ${_GLREMIX_RENDERER_DEPLOY_CONFIG_DIR}/shaders"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${_GLREMIX_RENDERER_DEPLOY_CONFIG_DIR}/shaders"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${CMAKE_CURRENT_BINARY_DIR}/shaders"
+            "${_GLREMIX_RENDERER_DEPLOY_CONFIG_DIR}/shaders"
+    )
+endif()


### PR DESCRIPTION
was previously incorrectly copying shaders after renderer build rather than shader compile target. not sure how it was working up to this point