### PR TITLE
Garbage Collection + Buffer Pools

### DIFF
--- a/glRemixRenderer/dx/d3d12_buffer.h
+++ b/glRemixRenderer/dx/d3d12_buffer.h
@@ -44,14 +44,6 @@ struct D3D12Buffer : D3D12Resource
     BufferDesc desc;
     friend class D3D12Context;  // It would be better if the internals were just exposed as a void
                                 // pointer or something
-
-    public:
-        void destroy()
-        {
-            allocation.Reset();
-            desc = {};
-            barrier_state = {};
-    }
 };
 
 }  // namespace glRemix::dx

--- a/glRemixRenderer/rt_app.h
+++ b/glRemixRenderer/rt_app.h
@@ -100,7 +100,6 @@ protected:
     int build_mesh_blas(const dx::D3D12Buffer& vertex_buffer, const dx::D3D12Buffer& index_buffer,
                         ID3D12GraphicsCommandList7* cmd_list);
     void build_tlas(ID3D12GraphicsCommandList7* cmd_list);
-    void delete_mesh(MeshRecord mesh);
 
 public:
     glRemixRenderer() = default;

--- a/glRemixRenderer/structs.h
+++ b/glRemixRenderer/structs.h
@@ -89,9 +89,8 @@ struct BufferPool
         return static_cast<uint32_t>(buffers.size() - 1);
     }
 
-    void destroy(uint32_t id)
+    void free(uint32_t id)
     {
-        buffers[id].destroy();
         free_indices.push_back(id);
     }
 


### PR DESCRIPTION
Create garbage collection system for mesh resources that have not been touched within a `frame_leniency` window. Also replaced mesh resource vectors with `Buffer Pools`, which act exactly like vectors except you can modify and delete in place without affecting indices of other mesh records.